### PR TITLE
Use Whitelist to determine the valid xtext gradle projects. fixes #6

### DIFF
--- a/releng/gradle-composite/build.gradle
+++ b/releng/gradle-composite/build.gradle
@@ -2,7 +2,7 @@ task('generatePrefs') {
     doLast {
         file('../../../').listFiles()
         .findAll { file ->
-            file.isDirectory() && file.getName().startsWith("xtext-") && !file.getName().startsWith("xtext-umbrella") && new File(file, "settings.gradle").exists()
+            file.isDirectory() && XTEXT_GRADLE_PROJECTS.contains(file.getName()) && new File(file, "settings.gradle").exists()
         }.each { file -> 
             fileTree(file).visit { FileVisitDetails details -> 
                 if (details.file.isDirectory() && new File(details.file, "build.gradle").exists() && (new File(details.file, '.settings')).exists()) {

--- a/releng/gradle-composite/gradle.properties
+++ b/releng/gradle-composite/gradle.properties
@@ -1,0 +1,1 @@
+XTEXT_GRADLE_PROJECTS=["xtext-lib","xtext-core","xtext-extras","xtext-idea","xtext-web","xtext-xtend"]

--- a/releng/gradle-composite/settings.gradle
+++ b/releng/gradle-composite/settings.gradle
@@ -2,7 +2,7 @@ if (!hasProperty('generatePrefs')) {
 	(files { file('../../../').listFiles() })
 .filter { 
     File it ->
-    it.isDirectory() && it.getName().startsWith("xtext-") && !it.getName().startsWith("xtext-umbrella") && new File(it, "settings.gradle").exists()
+    it.isDirectory() && XTEXT_GRADLE_PROJECTS.contains(it.getName()) && new File(it, "settings.gradle").exists()
 }.each {
     File it -> 
     includeBuild it


### PR DESCRIPTION
Use Whitelist to determine the valid xtext gradle projects. fixes #6

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>