### PR TITLE
Fix issue when git directories contain '.git' suffix

### DIFF
--- a/releng/gradle-composite/build.gradle
+++ b/releng/gradle-composite/build.gradle
@@ -2,7 +2,7 @@ task('generatePrefs') {
     doLast {
         file('../../../').listFiles()
         .findAll { file ->
-            file.isDirectory() && XTEXT_GRADLE_PROJECTS.contains(file.getName()) && new File(file, "settings.gradle").exists()
+            file.isDirectory() && XTEXT_GRADLE_PROJECTS.any{p->file.name.contains(p)} && new File(file, "settings.gradle").exists()
         }.each { file -> 
             println  "generating buildship prefs for " + file.path
             if (!(new File(file, '.settings')).exists()) {

--- a/releng/gradle-composite/settings.gradle
+++ b/releng/gradle-composite/settings.gradle
@@ -2,7 +2,7 @@ if (!hasProperty('generatePrefs')) {
 	(files { file('../../../').listFiles() })
 .filter { 
     File it ->
-    it.isDirectory() && XTEXT_GRADLE_PROJECTS.contains(it.getName()) && new File(it, "settings.gradle").exists()
+    it.isDirectory() && XTEXT_GRADLE_PROJECTS.any{p->it.name.contains(p)} && new File(it, "settings.gradle").exists()
 }.each {
     File it -> 
     includeBuild it


### PR DESCRIPTION
In my old workspace which was not set up with Oomph the repositories have a suffix `.git` in the directory name. The script was not able to generate the preference files for projects in there since the condition did not match.
The change will now test if the directory name contains one of the known project names, e.g. `xtext-core.git` contains `xtext-core`.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>