### PR TITLE
Copied non-self-contained features from xtext-eclipse and xtext-xtend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+/local-maven-repository/
 bin/
-.gradle/
 build/
+.gradle/
 *._trace
 *.xtendbin
 org.eclipse.buildship.core.prefs

--- a/releng/.project
+++ b/releng/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.target</name>
+	<name>xtext-umbrella</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/build.properties
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/build.properties
@@ -1,0 +1,1 @@
+bin.includes = feature.xml

--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/feature.xml
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/feature.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.emf.mwe2.language.sdk"
+      version="2.9.0.v201605261103"
+      label="Dummy Feature"
+      provider-name="Eclipse Xtext">
+
+   <description>
+      Dummy feature to satisfy Tycho's hunger for dependency resolution.
+   </description>
+
+</feature>

--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/pom.xml
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/pom.xml
@@ -1,0 +1,14 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>org.eclipse.xtext.sdk.parent</artifactId>
+		<version>2.11.0-SNAPSHOT</version>
+		<relativePath>../org.eclipse.xtext.sdk.parent</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<groupId>org.eclipse.emf</groupId>
+	<artifactId>org.eclipse.emf.mwe2.language.sdk</artifactId>
+	<version>2.9.0.v201605261103</version>
+</project>

--- a/releng/org.eclipse.xtend.sdk.feature/.project
+++ b/releng/org.eclipse.xtend.sdk.feature/.project
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.parent</name>
+	<name>org.eclipse.xtend.sdk.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.FeatureBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
 </projectDescription>

--- a/releng/org.eclipse.xtend.sdk.feature/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.xtend.sdk.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+#Tue Aug 18 18:37:57 CEST 2009
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1

--- a/releng/org.eclipse.xtend.sdk.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/releng/org.eclipse.xtend.sdk.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/releng/org.eclipse.xtend.sdk.feature/build.properties
+++ b/releng/org.eclipse.xtend.sdk.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/releng/org.eclipse.xtend.sdk.feature/feature.properties
+++ b/releng/org.eclipse.xtend.sdk.feature/feature.properties
@@ -1,0 +1,4 @@
+featureName=Xtend IDE
+
+providerName=Eclipse Xtend
+description=The Xtend Eclipse Plug-in. Includes everything you need to get started with programming Xtend in Eclipse.

--- a/releng/org.eclipse.xtend.sdk.feature/feature.xml
+++ b/releng/org.eclipse.xtend.sdk.feature/feature.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.xtend.sdk"
+      label="%featureName"
+      version="2.11.0.qualifier"
+      provider-name="%providerName"
+      plugin="org.eclipse.xtend.ide"
+      license-feature="org.eclipse.xtext.license"
+      license-feature-version="2.6.0.qualifier">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License
+v1.0 which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html Description here.
+   </copyright>
+
+   <license url="%licenseURL">
+      %license
+   </license>
+
+   <requires>
+      <import feature="org.eclipse.xtext.ui" version="2.11.0" match="equivalent"/>
+      <import feature="org.eclipse.xtext.xbase.lib" version="2.11.0" match="equivalent"/>
+      <import plugin="org.eclipse.xtend.lib" version="2.11.0" match="equivalent"/>
+      <import plugin="org.eclipse.xtend.lib.macro" version="2.11.0" match="equivalent"/>
+      <import plugin="org.eclipse.xtend.lib.source" version="2.11.0" match="equivalent"/>
+      <import plugin="org.eclipse.xtend.lib.macro.source" version="2.11.0" match="equivalent"/>
+      <import plugin="com.google.guava"/>
+      <import plugin="org.apache.commons.lang"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.xtend.core"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.ide.common"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.examples"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.doc"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.m2e"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.standalone"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+   <plugin
+         id="org.eclipse.xtend.core.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.ide.common.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.ide.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.m2e.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.standalone.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/releng/org.eclipse.xtend.sdk.feature/p2.inf
+++ b/releng/org.eclipse.xtend.sdk.feature/p2.inf
@@ -1,0 +1,2 @@
+instructions.configure=org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:http${#58}//download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,type:0,name:Xtext All In One - Releases,enabled:true); \
+  org.eclipse.equinox.p2.touchpoint.eclipse.addRepository(location:http${#58}//download.eclipse.org/modeling/tmf/xtext/updates/composite/releases/,type:1,name:Xtext All In One - Releases,enabled:true);

--- a/releng/org.eclipse.xtend.sdk.feature/pom.xml
+++ b/releng/org.eclipse.xtend.sdk.feature/pom.xml
@@ -1,0 +1,12 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>org.eclipse.xtext.sdk.parent</artifactId>
+		<version>2.11.0-SNAPSHOT</version>
+		<relativePath>../org.eclipse.xtext.sdk.parent</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<artifactId>org.eclipse.xtend.sdk</artifactId>
+</project>

--- a/releng/org.eclipse.xtext.examples.feature/.project
+++ b/releng/org.eclipse.xtext.examples.feature/.project
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.parent</name>
+	<name>org.eclipse.xtext.examples.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.FeatureBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
 </projectDescription>

--- a/releng/org.eclipse.xtext.examples.feature/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.xtext.examples.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+#Tue Aug 18 18:37:57 CEST 2009
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1

--- a/releng/org.eclipse.xtext.examples.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/releng/org.eclipse.xtext.examples.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/releng/org.eclipse.xtext.examples.feature/build.properties
+++ b/releng/org.eclipse.xtext.examples.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/releng/org.eclipse.xtext.examples.feature/feature.properties
+++ b/releng/org.eclipse.xtext.examples.feature/feature.properties
@@ -1,0 +1,10 @@
+
+
+featureName=Xtext Examples 
+
+
+providerName=Eclipse Xtext
+
+updateSiteName=Xtext Updates
+
+description=Xtext Examples Feature

--- a/releng/org.eclipse.xtext.examples.feature/feature.xml
+++ b/releng/org.eclipse.xtext.examples.feature/feature.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.xtext.examples"
+      label="%featureName"
+      version="2.11.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.xtext.license"
+      license-feature-version="2.6.0.qualifier">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License
+v1.0 which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html Description here.
+   </copyright>
+   <license url="http://www.eclipse.org/legal/epl-v10.html">
+      %license
+   </license>
+   <includes
+         id="org.eclipse.xtext.runtime"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.xtext.ui"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.xtext.xtext.ui.examples"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/releng/org.eclipse.xtext.examples.feature/pom.xml
+++ b/releng/org.eclipse.xtext.examples.feature/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>org.eclipse.xtext.sdk.parent</artifactId>
+		<version>2.11.0-SNAPSHOT</version>
+		<relativePath>../org.eclipse.xtext.sdk.parent</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<groupId>org.eclipse.xtext.feature</groupId>
+	<artifactId>org.eclipse.xtext.examples</artifactId>
+</project>

--- a/releng/org.eclipse.xtext.redist.feature/.project
+++ b/releng/org.eclipse.xtext.redist.feature/.project
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.parent</name>
+	<name>org.eclipse.xtext.redist.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.FeatureBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
 </projectDescription>

--- a/releng/org.eclipse.xtext.redist.feature/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.xtext.redist.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+#Tue Aug 18 18:37:57 CEST 2009
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1

--- a/releng/org.eclipse.xtext.redist.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/releng/org.eclipse.xtext.redist.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/releng/org.eclipse.xtext.redist.feature/build.properties
+++ b/releng/org.eclipse.xtext.redist.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/releng/org.eclipse.xtext.redist.feature/feature.properties
+++ b/releng/org.eclipse.xtext.redist.feature/feature.properties
@@ -1,0 +1,3 @@
+featureName=Xtext Redistributable 
+providerName=Eclipse Xtext
+description=The bits needed to use an Xtext-based language. You cannot develop new languages with it. For that you need the SDK.

--- a/releng/org.eclipse.xtext.redist.feature/feature.xml
+++ b/releng/org.eclipse.xtext.redist.feature/feature.xml
@@ -1,0 +1,313 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.xtext.redist"
+      label="%featureName"
+      version="2.11.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.xtext.license"
+      license-feature-version="2.6.0.qualifier">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License
+v1.0 which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html Description here.
+   </copyright>
+   <license url="http://www.eclipse.org/legal/epl-v10.html">
+      %license
+   </license>
+   <includes
+         id="org.eclipse.xtext.xbase"
+         version="0.0.0"/>
+
+   <requires>
+      <import plugin="com.google.guava" version="14.0.0" match="greaterOrEqual"/>
+      <import plugin="com.google.inject" version="3.0.0" match="greaterOrEqual"/>
+      <import plugin="org.objectweb.asm" version="5.0.1" match="compatible"/>
+      <import plugin="javax.inject" version="1.0.0" match="greaterOrEqual"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.xtext"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.util"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.util.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.antlr.runtime"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.commons.lang"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.log4j"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.logging"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.logging.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.builder"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.builder.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ecore"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ecore.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.smap"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.smap.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.shared"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.shared.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.shared.jdt38"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.shared.jdt38.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.shared"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.shared.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.edit"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.edit.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.lib"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.lib.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.lib.macro"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtend.lib.macro.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ide.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/releng/org.eclipse.xtext.redist.feature/pom.xml
+++ b/releng/org.eclipse.xtext.redist.feature/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>org.eclipse.xtext.sdk.parent</artifactId>
+		<version>2.11.0-SNAPSHOT</version>
+		<relativePath>../org.eclipse.xtext.sdk.parent</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<groupId>org.eclipse.xtext.feature</groupId>
+	<artifactId>org.eclipse.xtext.redist</artifactId>
+</project>

--- a/releng/org.eclipse.xtext.runtime.feature/.project
+++ b/releng/org.eclipse.xtext.runtime.feature/.project
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.parent</name>
+	<name>org.eclipse.xtext.runtime.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.FeatureBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
 </projectDescription>

--- a/releng/org.eclipse.xtext.runtime.feature/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.xtext.runtime.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+#Tue Aug 18 18:37:57 CEST 2009
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1

--- a/releng/org.eclipse.xtext.runtime.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/releng/org.eclipse.xtext.runtime.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/releng/org.eclipse.xtext.runtime.feature/build.properties
+++ b/releng/org.eclipse.xtext.runtime.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/releng/org.eclipse.xtext.runtime.feature/feature.properties
+++ b/releng/org.eclipse.xtext.runtime.feature/feature.properties
@@ -1,0 +1,4 @@
+featureName=Xtext Runtime 
+
+providerName=Eclipse Xtext
+description= Xtext Runtime Feature

--- a/releng/org.eclipse.xtext.runtime.feature/feature.xml
+++ b/releng/org.eclipse.xtext.runtime.feature/feature.xml
@@ -1,0 +1,211 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.xtext.runtime"
+      label="%featureName"
+      version="2.11.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.xtext.license"
+      license-feature-version="2.6.0.qualifier">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License
+v1.0 which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html Description here.
+   </copyright>
+   <license url="http://www.eclipse.org/legal/epl-v10.html">
+      %license
+   </license>
+   <requires>
+      <import plugin="org.eclipse.xtend"/>
+      <import plugin="org.eclipse.xpand"/>
+      <import plugin="org.eclipse.xtend.typesystem.emf"/>
+      <import plugin="com.google.guava" version="14.0.0" match="greaterOrEqual"/>
+      <import plugin="javax.inject" version="1.0.0" match="greaterOrEqual"/>
+      <import plugin="com.google.inject" version="3.0.0" match="greaterOrEqual"/>
+      <import plugin="org.objectweb.asm" version="5.0.1" match="compatible"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.xtext"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.generator"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.generator.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xtext.generator"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.xtext.generator.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.util"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.util.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.antlr.runtime"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.apache.log4j"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.logging"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.common.types.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.builder"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.builder.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ecore"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.ecore.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.smap"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.smap.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+    <plugin
+          id="org.eclipse.xtext.xtext.wizard"
+          download-size="0"
+          install-size="0"
+          version="0.0.0"
+          unpack="false"/>
+          
+    <plugin
+          id="org.eclipse.xtext.xtext.wizard.source"
+          download-size="0"
+          install-size="0"
+          version="0.0.0"
+          unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.builder.standalone"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.builder.standalone.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.java"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+         
+   <plugin
+         id="org.eclipse.xtext.java.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/releng/org.eclipse.xtext.runtime.feature/pom.xml
+++ b/releng/org.eclipse.xtext.runtime.feature/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>org.eclipse.xtext.sdk.parent</artifactId>
+		<version>2.11.0-SNAPSHOT</version>
+		<relativePath>../org.eclipse.xtext.sdk.parent</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<groupId>org.eclipse.xtext.feature</groupId>
+	<artifactId>org.eclipse.xtext.runtime</artifactId>
+</project>

--- a/releng/org.eclipse.xtext.sdk.p2-repository/.project
+++ b/releng/org.eclipse.xtext.sdk.p2-repository/.project
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.target</name>
+	<name>org.eclipse.xtext.sdk.p2-repository</name>
 	<comment></comment>
 	<projects>
 	</projects>

--- a/releng/org.eclipse.xtext.sdk.p2-repository/category.xml
+++ b/releng/org.eclipse.xtext.sdk.p2-repository/category.xml
@@ -1,20 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <site>
-   <feature url="features/org.eclipse.xtext.sdk_2.11.0.qualifier.jar" id="org.eclipse.xtext.sdk" version="2.11.0.qualifier">
-      <category name="Xtext"/>
-   </feature>
-   <feature url="features/org.eclipse.xtend.sdk_2.11.0.qualifier.jar" id="org.eclipse.xtend.sdk" version="2.11.0.qualifier">
-      <category name="Xtext"/>
-   </feature>
-   <bundle id="org.eclipse.lsp4j" version="0.0.0">
-      <category name="Xtext"/>
-   </bundle>
-   <bundle id="org.eclipse.lsp4j.jsonrpc" version="0.0.0">
-      <category name="Xtext"/>
-   </bundle>
-   <bundle id="com.google.gson" version="0.0.0">
-      <category name="Xtext"/>
-   </bundle>
-   
-   <category-def name="Xtext" label="Xtext"/>
+	<feature url="features/org.eclipse.xtext.sdk_2.11.0.qualifier.jar" id="org.eclipse.xtext.sdk" version="2.11.0.qualifier">
+		<category name="Xtext"/>
+	</feature>
+	<feature url="features/org.eclipse.xtend.sdk_2.11.0.qualifier.jar" id="org.eclipse.xtend.sdk" version="2.11.0.qualifier">
+		<category name="Xtext"/>
+	</feature>
+	<feature url="features/org.eclipse.lsp4j.sdk_0.1.0.qualifier.jar" id="org.eclipse.lsp4j.sdk" version="0.1.0.qualifier">
+		<category name="lsp4j"/>
+	</feature>
+	<category-def name="Xtext" label="Xtext"/>
+	<category-def name="lsp4j" label="LSP4J"/>
 </site>

--- a/releng/org.eclipse.xtext.sdk.parent/pom.xml
+++ b/releng/org.eclipse.xtext.sdk.parent/pom.xml
@@ -65,7 +65,6 @@
 				<artifactId>target-platform-configuration</artifactId>
 				<version>${tycho-version}</version>
 				<configuration>
-					<pomDependencies>consider</pomDependencies>
 					<target>
 						<artifact>
 							<groupId>org.eclipse.xtext</groupId>

--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -2,70 +2,145 @@
 <?pde version="3.8"?>
 <target name="org.eclipse.xtext.helios.target" sequenceNumber="6">
 <locations>
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.pde.api.tools.ee.feature.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
-<unit id="com.google.guava" version="0.0.0"/>
-
-<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
-
-<unit id="org.eclipse.xpand" version="0.0.0"/>
-<unit id="org.eclipse.xtend" version="0.0.0"/>
-<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
-<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
-
-<unit id="org.eclipse.m2e.feature.feature.group" version="1.5.1.20150109-1820"/>
-
-<repository location="http://download.eclipse.org/releases/luna/201502271000/"/>
-</location>
-
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.xtext.docs.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xtext.examples.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xtext.runtime.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xtext.redist.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xtext.ui.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xtext.xbase.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xtext.xtext.ui.feature.group" version="0.0.0"/>
-<unit id="org.eclipse.xtext.junit4" version="0.0.0"/>
-<unit id="org.eclipse.xtext.junit4.source" version="0.0.0"/>
-<unit id="org.eclipse.xtext.testing" version="0.0.0"/>
-<unit id="org.eclipse.xtext.testing.source" version="0.0.0"/>
-<unit id="org.eclipse.xtext.xbase.junit" version="0.0.0"/>
-<unit id="org.eclipse.xtext.xbase.junit.source" version="0.0.0"/>
-<unit id="org.eclipse.xtext.xbase.testing" version="0.0.0"/>
-<unit id="org.eclipse.xtext.xbase.testing.source" version="0.0.0"/>
-<unit id="org.eclipse.xtext.purexbase" version="0.0.0"/>
-<unit id="org.eclipse.xtext.purexbase.source" version="0.0.0"/>
-<unit id="org.eclipse.xtext.purexbase.ui" version="0.0.0"/>
-<unit id="org.eclipse.xtext.purexbase.ui.source" version="0.0.0"/>
-<unit id="org.eclipse.xtext.m2e" version="0.0.0"/>
-<unit id="org.eclipse.xtext.m2e.source" version="0.0.0"/>
-<unit id="org.eclipse.xtext.idea.generator" version="0.0.0"/>
-<unit id="org.eclipse.xtext.idea.generator.source" version="0.0.0"/>
-<unit id="org.eclipse.lsp4j" version="0.0.0"/>
-<unit id="org.eclipse.lsp4j.jsonrpc" version="0.0.0"/>
-<unit id="com.google.gson" version="0.0.0"/>
-<repository location="http://services.typefox.io/open-source/jenkins/job/xtext-eclipse/job/master/lastSuccessfulBuild/artifact/build/p2-repository/"/>
-</location>
-
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.xtend.sdk.feature.group" version="0.0.0"/>
-<repository location="http://services.typefox.io/open-source/jenkins/job/xtext-xtend/job/master/lastSuccessfulBuild/artifact/build/p2-repository/"/>
-</location>
-
-<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.emf.mwe2.language.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.eclipse.org/modeling/emft/mwe/updates/releases/2.9.0/"/>
-</location>
-
-<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="de.itemis.xtext.antlr.sdk.feature.group" version="0.0.0"/>
-<repository location="http://download.itemis.com/updates/releases/2.1.1/"/>
-</location>
-
+	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
+		<repository location="http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/p2-repository/"/>
+	</location>
+	
+	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.xtext.xbase.lib.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.lib" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.lib.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.lib.macro" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.lib.macro.source" version="0.0.0"/>
+		<repository location="http://services.typefox.io/open-source/jenkins/job/xtext-lib/job/msp_p2repo/lastStableBuild/artifact/build/p2-repository/"/>
+	</location>
+	
+	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.xtext" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ide" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ide.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.testing" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.testing.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.util" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.util.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.generator" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.generator.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.wizard" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.wizard.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.testlanguages" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.testlanguages.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.testlanguages.ide" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.testlanguages.ide.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.tests" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.tests.source" version="0.0.0"/>
+		<repository location="http://services.typefox.io/open-source/jenkins/job/xtext-core/job/msp_p2repo/lastStableBuild/artifact/build/p2-repository/"/>
+	</location>
+	
+	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.xtext.builder.standalone" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.builder.standalone.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ecore" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ecore.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.generator" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.generator.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.java" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.java.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.purexbase" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.purexbase.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.smap" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.smap.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.ide" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.ide.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.testing" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.testing.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.testlanguages" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.testlanguages.source" version="0.0.0"/>
+		<repository location="http://services.typefox.io/open-source/jenkins/job/xtext-extras/job/msp_p2repo/lastStableBuild/artifact/build/p2-repository/"/>
+	</location>
+	
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.xtext.docs.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.activities" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.activities.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.builder" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.builder.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.edit" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.edit.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.shared" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.shared.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.shared.jdt38" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.shared.jdt38.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.ui" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.common.types.ui.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.idea.generator" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.idea.generator.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.junit4" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.junit4.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.logging" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.logging.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.m2e" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.m2e.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.purexbase.ui" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.purexbase.ui.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.codetemplates" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.codetemplates.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.codetemplates.ui" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.codetemplates.ui.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.ecore" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.ecore.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.shared" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.shared.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.junit" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.junit.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.ui" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xbase.ui.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.ui" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.ui.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.ui.examples" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.ui.examples.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.ui.graph" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.xtext.ui.graph.source" version="0.0.0"/>
+		<repository location="http://services.typefox.io/open-source/jenkins/job/xtext-eclipse/job/msp_p2repo/lastStableBuild/artifact/build/p2-repository/"/>
+	</location>
+	
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
+		<unit id="org.eclipse.xtend.core" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.core.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.doc" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.examples" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.ide" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.ide.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.ide.common" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.ide.common.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.m2e" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.m2e.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.standalone" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.standalone.source" version="0.0.0"/>
+		<repository location="http://services.typefox.io/open-source/jenkins/job/xtext-xtend/job/master/lastStableBuild/artifact/build/p2-repository/"/>
+	</location>
+	
+	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
+		<unit id="org.eclipse.jdt.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.platform.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.pde.api.tools.ee.feature.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.pde.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.draw2d.feature.group" version="0.0.0"/>
+		<unit id="com.google.guava" version="0.0.0"/>
+		<unit id="org.eclipse.emf.sdk.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.xpand" version="0.0.0"/>
+		<unit id="org.eclipse.xtend" version="0.0.0"/>
+		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
+		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
+		<unit id="org.eclipse.m2e.feature.feature.group" version="1.5.1.20150109-1820"/>
+		<repository location="http://download.eclipse.org/releases/luna/201502271000/"/>
+	</location>
 </locations>
 </target>

--- a/releng/org.eclipse.xtext.ui.feature/.project
+++ b/releng/org.eclipse.xtext.ui.feature/.project
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.parent</name>
+	<name>org.eclipse.xtext.ui.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.FeatureBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
 </projectDescription>

--- a/releng/org.eclipse.xtext.ui.feature/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.xtext.ui.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+#Tue Aug 18 18:37:57 CEST 2009
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1

--- a/releng/org.eclipse.xtext.ui.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/releng/org.eclipse.xtext.ui.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/releng/org.eclipse.xtext.ui.feature/build.properties
+++ b/releng/org.eclipse.xtext.ui.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/releng/org.eclipse.xtext.ui.feature/feature.properties
+++ b/releng/org.eclipse.xtext.ui.feature/feature.properties
@@ -1,0 +1,4 @@
+featureName=Xtext UI 
+
+providerName=Eclipse Xtext
+description=Xtext UI Feature

--- a/releng/org.eclipse.xtext.ui.feature/feature.xml
+++ b/releng/org.eclipse.xtext.ui.feature/feature.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.xtext.ui"
+      label="%featureName"
+      version="2.11.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.xtext.license"
+      license-feature-version="2.6.0">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License
+v1.0 which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html Description here.
+   </copyright>
+
+   <license url="http://www.eclipse.org/legal/epl-v10.html">
+      %license
+   </license>
+
+   <includes
+         id="org.eclipse.xtext.runtime"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.apache.commons.lang"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.shared"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.shared.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.shared.jdt38"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.shared.jdt38.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         fragment="true"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.shared"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.shared.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.ecore"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.ecore.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.edit"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.common.types.edit.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ide.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/releng/org.eclipse.xtext.ui.feature/pom.xml
+++ b/releng/org.eclipse.xtext.ui.feature/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>org.eclipse.xtext.sdk.parent</artifactId>
+		<version>2.11.0-SNAPSHOT</version>
+		<relativePath>../org.eclipse.xtext.sdk.parent</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<groupId>org.eclipse.xtext.feature</groupId>
+	<artifactId>org.eclipse.xtext.ui</artifactId>
+</project>

--- a/releng/org.eclipse.xtext.xbase.feature/.project
+++ b/releng/org.eclipse.xtext.xbase.feature/.project
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.parent</name>
+	<name>org.eclipse.xtext.xbase.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.FeatureBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
 </projectDescription>

--- a/releng/org.eclipse.xtext.xbase.feature/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.xtext.xbase.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+#Tue Aug 18 18:37:57 CEST 2009
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1

--- a/releng/org.eclipse.xtext.xbase.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/releng/org.eclipse.xtext.xbase.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/releng/org.eclipse.xtext.xbase.feature/build.properties
+++ b/releng/org.eclipse.xtext.xbase.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/releng/org.eclipse.xtext.xbase.feature/feature.properties
+++ b/releng/org.eclipse.xtext.xbase.feature/feature.properties
@@ -1,0 +1,4 @@
+featureName=Xbase 
+
+providerName=Eclipse Xtext
+description= Xbase Feature

--- a/releng/org.eclipse.xtext.xbase.feature/feature.xml
+++ b/releng/org.eclipse.xtext.xbase.feature/feature.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.xtext.xbase"
+      label="%featureName"
+      version="2.11.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.xtext.license"
+      license-feature-version="2.6.0.qualifier">
+
+   <description>
+      %description
+   </description>
+   <license url="http://www.eclipse.org/legal/epl-v10.html">
+      %license
+   </license>
+   <copyright>
+      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License
+v1.0 which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html Description here.
+   </copyright>
+
+   <includes
+         id="org.eclipse.xtext.xbase.lib"
+         version="0.0.0"/>
+
+   <plugin
+         id="org.eclipse.xtext.xbase"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xbase.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xbase.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xbase.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xbase.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xbase.ide.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+</feature>

--- a/releng/org.eclipse.xtext.xbase.feature/pom.xml
+++ b/releng/org.eclipse.xtext.xbase.feature/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>org.eclipse.xtext.sdk.parent</artifactId>
+		<version>2.11.0-SNAPSHOT</version>
+		<relativePath>../org.eclipse.xtext.sdk.parent</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<groupId>org.eclipse.xtext.feature</groupId>
+	<artifactId>org.eclipse.xtext.xbase</artifactId>
+</project>

--- a/releng/org.eclipse.xtext.xtext.ui.feature/.project
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/.project
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <projectDescription>
-	<name>org.eclipse.xtext.sdk.parent</name>
+	<name>org.eclipse.xtext.xtext.ui.feature</name>
 	<comment></comment>
 	<projects>
 	</projects>
 	<buildSpec>
 		<buildCommand>
-			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<name>org.eclipse.pde.FeatureBuilder</name>
 			<arguments>
 			</arguments>
 		</buildCommand>
 	</buildSpec>
 	<natures>
-		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
 </projectDescription>

--- a/releng/org.eclipse.xtext.xtext.ui.feature/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,3 @@
+#Tue Aug 18 18:37:57 CEST 2009
+eclipse.preferences.version=1
+encoding/<project>=ISO-8859-1

--- a/releng/org.eclipse.xtext.xtext.ui.feature/.settings/org.eclipse.core.runtime.prefs
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/.settings/org.eclipse.core.runtime.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+line.separator=\n

--- a/releng/org.eclipse.xtext.xtext.ui.feature/build.properties
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/build.properties
@@ -1,0 +1,2 @@
+bin.includes = feature.xml,\
+               feature.properties

--- a/releng/org.eclipse.xtext.xtext.ui.feature/feature.properties
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/feature.properties
@@ -1,0 +1,4 @@
+featureName=Xtext Xtext UI 
+
+providerName=Eclipse Xtext
+description=Xtext Xtext UI Feature

--- a/releng/org.eclipse.xtext.xtext.ui.feature/feature.xml
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/feature.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feature
+      id="org.eclipse.xtext.xtext.ui"
+      label="%featureName"
+      version="2.11.0.qualifier"
+      provider-name="%providerName"
+      license-feature="org.eclipse.xtext.license"
+      license-feature-version="2.6.0.qualifier">
+
+   <description>
+      %description
+   </description>
+
+   <copyright>
+      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+
+All rights reserved. This program and the accompanying materials
+are made available under the terms of the Eclipse Public License
+v1.0 which accompanies this distribution, and is available at
+http://www.eclipse.org/legal/epl-v10.html Description here.
+   </copyright>
+   <license url="http://www.eclipse.org/legal/epl-v10.html">
+      %license
+   </license>
+   <includes
+         id="org.eclipse.xtext.ui"
+         version="0.0.0"/>
+
+   <requires>
+      <import plugin="org.eclipse.emf.mwe2.runtime" version="2.7.0" match="greaterOrEqual"/>
+   </requires>
+
+   <plugin
+         id="org.eclipse.xtext.activities"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.activities.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xtext.ui"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xtext.ui.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xtext.ui.graph"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.xtext.ui.graph.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.doc"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"/>
+
+</feature>

--- a/releng/org.eclipse.xtext.xtext.ui.feature/pom.xml
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/pom.xml
@@ -1,0 +1,13 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.eclipse.xtext</groupId>
+		<artifactId>org.eclipse.xtext.sdk.parent</artifactId>
+		<version>2.11.0-SNAPSHOT</version>
+		<relativePath>../org.eclipse.xtext.sdk.parent</relativePath>
+	</parent>
+	<packaging>eclipse-feature</packaging>
+	<groupId>org.eclipse.xtext.feature</groupId>
+	<artifactId>org.eclipse.xtext.xtext.ui</artifactId>
+</project>

--- a/releng/pom.xml
+++ b/releng/pom.xml
@@ -18,8 +18,16 @@
 		<module>org.eclipse.xtext.sdk.target</module>
 		<module>org.eclipse.xtext.sdk.parent</module>
 		<module>org.eclipse.xtext.license.feature</module>
+		<module>org.eclipse.xtext.examples.feature</module>
+		<module>org.eclipse.xtext.redist.feature</module>
+		<module>org.eclipse.xtext.runtime.feature</module>
 		<module>org.eclipse.xtext.sdk.feature</module>
+		<module>org.eclipse.xtext.ui.feature</module>
+		<module>org.eclipse.xtext.xbase.feature</module>
+		<module>org.eclipse.xtext.xtext.ui.feature</module>
+		<module>org.eclipse.xtend.sdk.feature</module>
 		<module>org.eclipse.xtext.sdk.p2-repository</module>
+		<module>org.eclipse.emf.mwe2.language.sdk.dummy</module>
 	</modules>
 
 </project>


### PR DESCRIPTION
See eclipse/xtext#1085.

Tycho does no longer consider pom dependencies, but fetches all dependencies from upstream p2 repositories (eclipse/xtext-lib#27, eclipse/xtext-core#194, eclipse/xtext-extras#78). Some features that are not self-contained, i.e. include plug-ins from upstream repositories, have been copied from xtext-eclipse and xtext-xtend.