### PR TITLE
Removed LSP4J from Xtext update site

### DIFF
--- a/releng/org.eclipse.xtext.sdk.p2-repository/category.xml
+++ b/releng/org.eclipse.xtext.sdk.p2-repository/category.xml
@@ -6,15 +6,5 @@
 	<feature id="org.eclipse.xtend.sdk" version="2.12.0.qualifier">
 		<category name="Xtext"/>
 	</feature>
-	<feature id="org.eclipse.lsp4j.sdk" version="0.2.0.qualifier">
-		<category name="lsp4j"/>
-	</feature>
-	<bundle id="com.google.gson" version="2.7.0.v20170129-0911">
-		<category name="lsp4j"/>
-	</bundle>
-	<bundle id="com.google.gson.source" version="2.7.0.v20170129-0911">
-		<category name="lsp4j"/>
-	</bundle>
 	<category-def name="Xtext" label="Xtext"/>
-	<category-def name="lsp4j" label="LSP4J"/>
 </site>

--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -3,11 +3,6 @@
 <target name="org.eclipse.xtext.helios.target" sequenceNumber="6">
 <locations>
 	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="org.eclipse.lsp4j.sdk.feature.group" version="0.0.0"/>
-		<repository location="http://services.typefox.io/open-source/jenkins/job/lsp4j/job/master/lastStableBuild/artifact/build/p2-repository/"/>
-	</location>
-	
-	<location includeAllPlatforms="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="org.eclipse.xtext.xbase.lib.feature.group" version="0.0.0"/>
 		<unit id="org.eclipse.xtend.lib" version="0.0.0"/>
 		<unit id="org.eclipse.xtend.lib.source" version="0.0.0"/>


### PR DESCRIPTION
We once added LSP4J to the Xtext update site in order to not break clients who use Xtext in a Tycho build: `org.eclipse.xtext.ide` has an optional dependency on `org.eclipse.lsp4j`, and Tycho tries to resolve it in any case. Now the situation is different since both Xtext and LSP4J will be part of the Oxygen aggregated update site. Clients can fetch LSP4J either from there or from the [release update site](http://download.eclipse.org/lsp4j/updates/releases/).