### PR TITLE
migrated codetemplates to new wf. 

### DIFF
--- a/releng/org.eclipse.xtext.redist.feature/feature.xml
+++ b/releng/org.eclipse.xtext.redist.feature/feature.xml
@@ -241,6 +241,20 @@ http://www.eclipse.org/legal/epl-v10.html Description here.
          unpack="false"/>
 
    <plugin
+         id="org.eclipse.xtext.ui.codetemplates.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.ide.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
          id="org.eclipse.xtext.ui.codetemplates.ui"
          download-size="0"
          install-size="0"

--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -91,6 +91,8 @@
 		<unit id="org.eclipse.xtext.ui.source" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.ui.codetemplates" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.ui.codetemplates.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.codetemplates.ide" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.ui.codetemplates.ide.source" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.ui.codetemplates.ui" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.ui.codetemplates.ui.source" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.ui.ecore" version="0.0.0"/>

--- a/releng/org.eclipse.xtext.ui.feature/feature.xml
+++ b/releng/org.eclipse.xtext.ui.feature/feature.xml
@@ -134,6 +134,19 @@ http://www.eclipse.org/legal/epl-v10.html Description here.
          install-size="0"
          version="0.0.0"
          unpack="false"/>
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.ide"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.ui.codetemplates.ide.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
 
    <plugin
          id="org.eclipse.xtext.ui.codetemplates.ui"


### PR DESCRIPTION
migrated codetemplates to new wf. https://github.com/eclipse/xtext-eclipse/issues/355

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>