### PR TITLE
[eclipse/xtext#1160] Update copyright date range

### DIFF
--- a/releng/org.eclipse.xtend.sdk.feature/feature.xml
+++ b/releng/org.eclipse.xtend.sdk.feature/feature.xml
@@ -13,7 +13,7 @@
    </description>
 
    <copyright>
-      Copyright (c) 2011 itemis AG (http://www.itemis.eu) and others.
+      Copyright (c) 2011, 2018 itemis AG (http://www.itemis.eu) and others.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.docs.feature/feature.xml
+++ b/releng/org.eclipse.xtext.docs.feature/feature.xml
@@ -12,7 +12,7 @@
    </description>
 
    <copyright>
-      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+      Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.examples.feature/feature.xml
+++ b/releng/org.eclipse.xtext.examples.feature/feature.xml
@@ -12,7 +12,7 @@
    </description>
 
    <copyright>
-      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+      Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.license.feature/feature.xml
+++ b/releng/org.eclipse.xtext.license.feature/feature.xml
@@ -10,7 +10,7 @@
    </description>
    
    <copyright>
-      Copyright (c) 2016 Xtext Committers and Contributors.
+      Copyright (c) 2016, 2018 Xtext Committers and Contributors.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.redist.feature/feature.xml
+++ b/releng/org.eclipse.xtext.redist.feature/feature.xml
@@ -12,7 +12,7 @@
    </description>
 
    <copyright>
-      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+      Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.runtime.feature/feature.xml
+++ b/releng/org.eclipse.xtext.runtime.feature/feature.xml
@@ -12,7 +12,7 @@
    </description>
 
    <copyright>
-      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+      Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.sdk.feature/feature.xml
+++ b/releng/org.eclipse.xtext.sdk.feature/feature.xml
@@ -14,7 +14,7 @@
    </description>
 
    <copyright>
-      Copyright (c) 2016 Xtext Committers and Contributors.
+      Copyright (c) 2016, 2018 Xtext Committers and Contributors.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.ui.feature/feature.xml
+++ b/releng/org.eclipse.xtext.ui.feature/feature.xml
@@ -12,7 +12,7 @@
    </description>
 
    <copyright>
-      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+      Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.xbase.feature/feature.xml
+++ b/releng/org.eclipse.xtext.xbase.feature/feature.xml
@@ -14,7 +14,7 @@
       %license
    </license>
    <copyright>
-      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+      Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License

--- a/releng/org.eclipse.xtext.xtext.ui.feature/feature.xml
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/feature.xml
@@ -12,7 +12,7 @@
    </description>
 
    <copyright>
-      Copyright (c) 2009 itemis AG (http://www.itemis.eu) and others.
+      Copyright (c) 2009, 2018 itemis AG (http://www.itemis.eu) and others.
 
 All rights reserved. This program and the accompanying materials
 are made available under the terms of the Eclipse Public License


### PR DESCRIPTION
For feature.xml's I assume that they should be updated to the current (release) year, not the change date of change of the file itself.