### PR TITLE
[eclipse/xtext#1214] fixed adjustBuildPipelines to adjust maven integ tests too

### DIFF
--- a/adjustPipelines.sh
+++ b/adjustPipelines.sh
@@ -101,7 +101,7 @@ do
 		if isBranch
 		then
 			dropDir
-			find $directory -name pom.xml -type f -path '*.maven.parent/*' -print | while read -r pom
+			find $directory -name pom.xml -type f -path '*.maven.parent/*' -print -o -name pom.xml -type f -path '*.maven.plugin/src/test/resources/it/generate/pom.xml' -print | while read -r pom
 			do
 				echo "Redirecting parent pom.xml files in $pom to $branchname"
 				./allDirectories | while read -r repo


### PR DESCRIPTION
[eclipse/xtext#1214] fixed adjustBuildPipelines to adjust maven integ tests too

depends on https://github.com/eclipse/xtext-maven/pull/28

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>