### PR TITLE
Keep the branchname in the TP but only replace the Jenkins URL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,14 +17,6 @@ node {
 		dir('.m2/repository/org/eclipse/xtend') { deleteDir() }
 		
 		sh '''
-			branchname=${1:-master}
-			
-			escaped() {
-				echo $branchname | sed 's/\\//%252F/g'
-			}
-			
-			escapedBranch=$(escaped)
-			
 			sed_inplace() {
 				if [[ "$OSTYPE" == "darwin"* ]]; then
 					sed -i '' "$@"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,8 +36,8 @@ node {
 			targetfiles="$(find releng -type f -iname '*.target')"
 			for targetfile in $targetfiles
 			do
-				echo "Redirecting target platforms in $targetfile to $branchname"
-				sed_inplace "s?<repository location=\\".*/job/\\([^/]*\\)/job/[^/]*/?<repository location=\\"$JENKINS_URL/job/\\1/job/$escapedBranch/?" $targetfile
+				echo "Redirecting target platforms in $targetfile to $JENKINS_URL"
+				sed_inplace "s?<repository location=\\".*/job/\\([^/]*\\)/job/\\([^/]*\\)/?<repository location=\\"$JENKINS_URL/job/\\1/job/\\2/?" $targetfile
 			done
 		'''
 	}


### PR DESCRIPTION
Problem is, that the branchname is expected to come from a script parameter
but the sh script in the Jenkinsfile does not take any parameters. It always
replaces the stuff by 'master'