### PR TITLE
remove obsolete call subLastXtext eclipse and maven

### DIFF
--- a/allDirectories
+++ b/allDirectories
@@ -7,4 +7,4 @@ function subLastXtext {
     cat locations.properties | head -n 1 | rev | sed "s/${replace}/${by}/" | rev
 }
 
-cat <(subLastXtext "umbrella") <(subLastXtext "eclipse") <(subLastXtext "maven") <(cat locations.properties) | cut -d "=" -f2 - | grep "\/"
+cat <(subLastXtext "umbrella") <(cat locations.properties) | cut -d "=" -f2 - | grep "\/"


### PR DESCRIPTION
location.properties already contains xtext-eclipse and xtext-maven.
These options were triggering git calls with gitAll on xtext-eclipse and
xtext-maven twice

Example:
```
./gitAll checkout master
Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-umbrella
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-eclipse
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-maven
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-lib
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-core
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-extras
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-eclipse
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-idea
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-xtend
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-web
Already on 'master'
Your branch is up to date with 'origin/master'.

Processing /Users/thoms/Development/Eclipse/xtext-dev/git/xtext-maven
Already on 'master'
Your branch is up to date with 'origin/master'.
```