### PR TITLE
[eclipse/xtext#1412] use orbit for 2019-06

### DIFF
--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -160,7 +160,7 @@
 		<unit id="org.objectweb.asm.source" version="7.0.0.v20181030-2244"/>
 		<unit id="org.objectweb.asm.tree" version="7.0.0.v20181030-2244"/>
 		<unit id="org.objectweb.asm.tree.source" version="7.0.0.v20181030-2244"/>
-		<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-03"/>
+		<repository location="http://download.eclipse.org/modeling/tmf/xtext/updates/orbit/2019-06"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1412] use orbit for 2019-06
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>