### PR TITLE
[eclipse/xtext#1424] Change default Jenkins

### DIFF
--- a/adjustPipelines.sh
+++ b/adjustPipelines.sh
@@ -41,7 +41,7 @@ sed_inplace() {
 }
 
 if [[ -z "${JENKINS_URL}" ]]; then
-	JENKINS_URL="https://services.typefox.io/open-source/jenkins"
+	JENKINS_URL="https://ci.eclipse.org/xtext"
 fi
 echo "JENKINS_URL=$JENKINS_URL"
 


### PR DESCRIPTION
Use https://ci.eclipse.org/xtext as default Jenkins URL

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>