### PR TITLE
[eclipse/xtext#1467] Add JIRO as known environment qualifier for build notification message

### DIFF
--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -129,6 +129,8 @@ spec:
         def envName = ''
         if (env.JENKINS_URL.contains('ci.eclipse.org/xtext')) {
           envName = ' (JIPP)'
+        } else if (env.JENKINS_URL.contains('ci-staging.eclipse.org/xtext')) {
+          envName = ' (JIRO)'
         } else if (env.JENKINS_URL.contains('jenkins.eclipse.org/xtext')) {
           envName = ' (CBI)'
         } else if (env.JENKINS_URL.contains('typefox.io')) {


### PR DESCRIPTION
[eclipse/xtext#1467] Add JIRO as known environment qualifier for build
notification message

Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>