### PR TITLE
[#138] Removed duplicate settings.xml provisioning

### DIFF
--- a/CBI.Jenkinsfile
+++ b/CBI.Jenkinsfile
@@ -115,20 +115,16 @@ spec:
 
     stage('Maven Build') {
       steps {
-        configFileProvider(
-          [configFile(fileId: '7a78c736-d3f8-45e0-8e69-bf07c27b97ff', variable: 'MAVEN_SETTINGS')]) {
-          sh '''
-            mvn \
-              -s $MAVEN_SETTINGS \
-              -f releng \
-              --batch-mode \
-              --update-snapshots \
-              -fae \
-              -Dmaven.repo.local=$WORKSPACE/.m2/repository \
-              -Dtycho.disableP2Mirrors=true \
-              clean install
-          '''
-        }
+        sh '''
+          mvn \
+            -f releng \
+            --batch-mode \
+            --update-snapshots \
+            -fae \
+            -Dmaven.repo.local=$WORKSPACE/.m2/repository \
+            -Dtycho.disableP2Mirrors=true \
+            clean install
+        '''
       }
     }
   }


### PR DESCRIPTION
The config file id for settings.xml was invalid. Since the settings.xml
is already provided by volume mount in the pod configuration, additional
provisioning was obsolete anyway.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>