### PR TITLE
[https://github.com/eclipse/xtext/issues/1486]

### DIFF
--- a/releng/org.eclipse.xtext.sdk.feature/feature.xml
+++ b/releng/org.eclipse.xtext.sdk.feature/feature.xml
@@ -5,7 +5,7 @@
       version="2.20.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.xtext"
-      image="modeling32.png"
+      image="xtext32.png"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
 


### PR DESCRIPTION
- Use xtext32.png instead of modeling32.png for the feature image.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>