### PR TITLE
[https://github.com/eclipse/xtext/issues/1486]

### DIFF
--- a/releng/org.eclipse.xtext.sdk.feature/feature.xml
+++ b/releng/org.eclipse.xtext.sdk.feature/feature.xml
@@ -5,7 +5,6 @@
       version="2.20.0.qualifier"
       provider-name="%providerName"
       plugin="org.eclipse.xtext"
-      image="xtext32.png"
       license-feature="org.eclipse.license"
       license-feature-version="0.0.0">
 


### PR DESCRIPTION
- Remove unnecessary image="xtext32.png" from the feature.xml file.

Signed-off-by: Tamas Miklossy <miklossy@itemis.de>