### PR TITLE
[eclipse/xtext#1538] use orbit 2019-12

### DIFF
--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -162,7 +162,7 @@
 		<unit id="org.objectweb.asm.tree.source" version="7.1.0.v20190412-2143"/>
 		<unit id="io.github.classgraph" version="4.8.35.v20190528-1517"/>
 		<unit id="io.github.classgraph.source" version="4.8.35.v20190528-1517"/>
-		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-09"/>
+		<repository location="https://download.eclipse.org/tools/orbit/downloads/2019-12"/>
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">


### PR DESCRIPTION
[eclipse/xtext#1538] use orbit 2019-12
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>