### PR TITLE
[eclipse/xtext#1618] Trim trailing whitespace from shell call result

### DIFF
--- a/releng/jenkins/sign-and-deploy/Jenkinsfile
+++ b/releng/jenkins/sign-and-deploy/Jenkinsfile
@@ -279,7 +279,7 @@ spec:
       }
       steps {
         script {
-          env.XTEXT_VERSION=sh returnStdout: true, script: '$SCRIPTS/get_property.sh publishing/build-result/publisher.properties version'
+          env.XTEXT_VERSION=sh (returnStdout: true, script: '$SCRIPTS/get_property.sh publishing/build-result/publisher.properties version').trim()
           env.NEW_XTEXT_VERSION = getNewXtextVersion(env.XTEXT_VERSION, "minor")
           echo "Triggering Xtext version update ${env.XTEXT_VERSION} -> ${env.NEW_XTEXT_VERSION}"
           build job: 'releng/bot-updates',


### PR DESCRIPTION
The result from the invocation of get_property.sh needs to be trimmed,
as it contains a trailing newline. This made the build fail while trying
to trigger the version update.

Signed-off-by: Karsten Thoms <karsten.thoms@itemis.de>