### PR TITLE
Add xtext.m2e and xtext.buildship to features xtext.redist and xtext.ui

### DIFF
--- a/releng/org.eclipse.xtext.redist.feature/feature.xml
+++ b/releng/org.eclipse.xtext.redist.feature/feature.xml
@@ -339,4 +339,32 @@ http://www.eclipse.org/legal/epl-v10.html Description here.
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.xtext.m2e"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.m2e.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.buildship"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.buildship.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>

--- a/releng/org.eclipse.xtext.sdk.feature/feature.xml
+++ b/releng/org.eclipse.xtext.sdk.feature/feature.xml
@@ -115,18 +115,4 @@ http://www.eclipse.org/legal/epl-v10.html Description here.
          version="0.0.0"
          unpack="false"/>
 
-   <plugin
-         id="org.eclipse.xtext.m2e"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
-   <plugin
-         id="org.eclipse.xtext.m2e.source"
-         download-size="0"
-         install-size="0"
-         version="0.0.0"
-         unpack="false"/>
-
 </feature>

--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -70,6 +70,8 @@
 		<unit id="org.eclipse.xtext.activities.source" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.builder" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.builder.source" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.buildship" version="0.0.0"/>
+		<unit id="org.eclipse.xtext.buildship.source" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.common.types.edit" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.common.types.edit.source" version="0.0.0"/>
 		<unit id="org.eclipse.xtext.common.types.shared" version="0.0.0"/>
@@ -177,6 +179,7 @@
 		<unit id="org.eclipse.xtend" version="0.0.0"/>
 		<unit id="org.eclipse.xtend.typesystem.emf" version="0.0.0"/>
 		<unit id="org.eclipse.m2e.feature.feature.group" version="0.0.0"/>
+		<unit id="org.eclipse.buildship.feature.group" version="0.0.0"/>
 		<repository location="https://download.eclipse.org/releases/oxygen/201804111000"/>
 	</location>
 

--- a/releng/org.eclipse.xtext.ui.feature/feature.xml
+++ b/releng/org.eclipse.xtext.ui.feature/feature.xml
@@ -205,4 +205,32 @@ http://www.eclipse.org/legal/epl-v10.html Description here.
          version="0.0.0"
          unpack="false"/>
 
+   <plugin
+         id="org.eclipse.xtext.m2e"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.m2e.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.buildship"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
+   <plugin
+         id="org.eclipse.xtext.buildship.source"
+         download-size="0"
+         install-size="0"
+         version="0.0.0"
+         unpack="false"/>
+
 </feature>


### PR DESCRIPTION
The functionality of both plugins does make sense in the context of arbitrary Xtext languages and should be available by default. It does not make much sense to have these only as part of the SDK.