### PR TITLE
[eclipse/xtext#1673] udpate to MWE 2.11.2

### DIFF
--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/feature.xml
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.eclipse.emf.mwe2.language.sdk"
-      version="2.11.2.v20191121-1148"
+      version="2.11.2.v20200224-0816"
       label="Dummy Feature"
       provider-name="Eclipse Xtext">
 

--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/pom.xml
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/pom.xml
@@ -10,5 +10,5 @@
 	<packaging>eclipse-feature</packaging>
 	<groupId>org.eclipse.emf</groupId>
 	<artifactId>org.eclipse.emf.mwe2.language.sdk</artifactId>
-	<version>2.11.2.v20191121-1148</version>
+	<version>2.11.2.v20200224-0816</version>
 </project>

--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -188,7 +188,7 @@
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="false" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S202002170915/"/>
+		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.11.2/"/>
 		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
 	</location>
 


### PR DESCRIPTION
[eclipse/xtext#1673] udpate to MWE 2.11.2
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>