### PR TITLE
[eclipse/xtext#1812] Use centos-7 pod template & config. JDK

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,13 +30,14 @@ pipeline {
   }
 
   stages {
-    stage('Checkout') {
+    stage('Initialize') {
       steps {
         script {
           properties([
             [$class: 'GithubProjectProperty', displayName: '', projectUrlStr: 'https://github.com/eclipse/xtext-core/'],
             [$class: 'RebuildSettings', autoRebuild: false, rebuildDisabled: false]
           ])
+          currentBuild.displayName = String.format("#%s(%s)", BUILD_NUMBER, javaVersion(JDK_VERSION))
         }
 
         sh '''
@@ -149,5 +150,13 @@ def getReleaseType () {
     return env.BRANCH_NAME.substring(env.BRANCH_NAME.lastIndexOf('.')+1)
   } else {
     return "Integration"
+  }
+}
+
+def javaVersion(String version) {
+  if (!version.contains('-jdk')) {
+    return 'jdk15'
+  } else {
+    return version.replaceAll(".*-(jdk\\d+).*", "\$1")
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,58 +1,15 @@
 pipeline {
   agent {
     kubernetes {
-      label 'xtext-umbrella-' + (env.BRANCH_NAME.replace('/','_')) + '-' + env.BUILD_NUMBER
-      defaultContainer 'xtext-buildenv'
-      yaml '''
-apiVersion: v1
-kind: Pod
-spec:
-  containers:
-  - name: jnlp
-    args: ['\$(JENKINS_SECRET)', '\$(JENKINS_NAME)']
-    resources:
-      limits:
-        memory: "0.4Gi"
-        cpu: "0.2"
-      requests:
-        memory: "0.4Gi"
-        cpu: "0.2"
-    volumeMounts:
-    - mountPath: /home/jenkins/.ssh
-      name: volume-known-hosts
-  - name: xtext-buildenv
-    image: docker.io/smoht/xtext-buildenv:0.7
-    tty: true
-    resources:
-      limits:
-        memory: "3.6Gi"
-        cpu: "1.0"
-      requests:
-        memory: "3.6Gi"
-        cpu: "1.0"
-    volumeMounts:
-    - name: settings-xml
-      mountPath: /home/jenkins/.m2/settings.xml
-      subPath: settings.xml
-      readOnly: true
-    - name: m2-repo
-      mountPath: /home/jenkins/.m2/repository
-    - name: volume-known-hosts
-      mountPath: /home/jenkins/.ssh
-  volumes:
-  - name: volume-known-hosts
-    configMap:
-      name: known-hosts
-  - name: settings-xml
-    secret:
-      secretName: m2-secret-dir
-      items:
-      - key: settings.xml
-        path: settings.xml
-  - name: m2-repo
-    emptyDir: {}
-    '''
+      label 'centos-7'
     }
+  }
+
+  parameters {
+    // see https://wiki.eclipse.org/Jenkins#JDK
+    choice(name: 'JDK_VERSION', description: 'Which JDK should be used?', choices: [
+       'adoptopenjdk-hotspot-jdk8-latest', 'adoptopenjdk-hotspot-jdk11-latest', 'adoptopenjdk-hotspot-latest'
+    ])
   }
 
   options {
@@ -67,6 +24,11 @@ spec:
     githubPush()
   }
   
+  tools {
+     maven "apache-maven-latest"
+     jdk "${params.JDK_VERSION}"
+  }
+
   stages {
     stage('Checkout') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
   }
   
   tools {
-     maven "apache-maven-latest"
+     maven "apache-maven-3.6.3"
      jdk "${params.JDK_VERSION}"
   }
 

--- a/releng/jenkins/release-simrel-update/Jenkinsfile
+++ b/releng/jenkins/release-simrel-update/Jenkinsfile
@@ -82,7 +82,7 @@ pipeline {
             git diff
             git commit --signoff -m "Xtext $XTEXT_VERSION_LABEL contribution to SimRel $SIMREL_LABEL"
           '''
-          withMaven(maven: 'apache-maven-latest') {
+          withMaven(maven: 'apache-maven-3.6.3') {
             sh '''
               mvn -Pvalidate clean test -B
             '''


### PR DESCRIPTION
The centos-7 pod template provides a configuration suitable for most
builds. This makes the configuration of the custom container obsolete.

Additionally JDK versions are now selectable by parameter.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>