### PR TITLE
[eclipse/xtext#1502] Remove old milestones when deploying new M1

### DIFF
--- a/releng/jenkins/sign-and-deploy/Jenkinsfile
+++ b/releng/jenkins/sign-and-deploy/Jenkinsfile
@@ -116,6 +116,26 @@ spec:
       }
     }
     
+    stage('Clean up old milestones') {
+      when {
+        environment name: 'RELEASE_TYPE', value: 'M1'
+      }
+      steps {
+        sshagent(['projects-storage.eclipse.org-bot-ssh']) {
+          container ('jnlp') {
+            sh '''
+              // Remove old milestones from update site
+              // Intentionally leave composite*.xml files, as they will be updated at the end.
+              // Intentionally leave p2.index file so that we don't have to recreate it.
+              ssh genie.xtext@projects-storage.eclipse.org "rm -rf /home/data/httpd/download.eclipse.org/modeling/tmf/xtext/updates/milestones/S*"
+              // Remove old milestones from drop location
+              ssh genie.xtext@projects-storage.eclipse.org "rm -rf /home/data/httpd/download.eclipse.org/modeling/tmf/xtext/downloads/drops/*/S*"
+            '''
+          }
+        }
+      }
+    }
+
     stage('Sign & Upload to OSSRH') {
       steps {
         container ('xtext-buildenv') {


### PR DESCRIPTION
[eclipse/xtext#1502] Remove old milestones when deploying new M1

Signed-off-by: Nico Prediger <mail@nicoprediger.de>