### PR TITLE
[eclipse/xtext#1866] update to MWE(2) 1.6.0/2.12.0 M2

### DIFF
--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/feature.xml
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.eclipse.emf.mwe2.language.sdk"
-      version="2.11.3.v20200520-0756"
+      version="2.12.0.v20201029-2115"
       label="Dummy Feature"
       provider-name="Eclipse Xtext">
 

--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/pom.xml
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/pom.xml
@@ -10,5 +10,5 @@
 	<packaging>eclipse-feature</packaging>
 	<groupId>org.eclipse.emf</groupId>
 	<artifactId>org.eclipse.emf.mwe2.language.sdk</artifactId>
-	<version>2.11.3.v20200520-0756</version>
+	<version>2.12.0.v20201029-2115</version>
 </project>

--- a/releng/org.eclipse.xtext.sdk.feature/feature.xml
+++ b/releng/org.eclipse.xtext.sdk.feature/feature.xml
@@ -71,7 +71,7 @@ SPDX-License-Identifier: EPL-2.0
       <import plugin="org.eclipse.emf.common" version="2.17.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.ecore.source" version="2.20.0" match="greaterOrEqual"/>
       <import plugin="org.eclipse.emf.common.source" version="2.17.0" match="greaterOrEqual"/>
-      <import feature="org.eclipse.emf.mwe2.language.sdk" version="2.11.3" match="greaterOrEqual"/>
+      <import feature="org.eclipse.emf.mwe2.language.sdk" version="2.12.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -188,7 +188,7 @@
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.11.3/"/>
+		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S202010292115/"/>
 		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
 	</location>
 

--- a/releng/org.eclipse.xtext.xtext.ui.feature/feature.xml
+++ b/releng/org.eclipse.xtext.xtext.ui.feature/feature.xml
@@ -35,7 +35,7 @@ SPDX-License-Identifier: EPL-2.0
          optional="true"/>
 
    <requires>
-      <import plugin="org.eclipse.emf.mwe2.runtime" version="2.11.3" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.emf.mwe2.runtime" version="2.12.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin


### PR DESCRIPTION
[eclipse/xtext#1866] update to MWE(2) 1.6.0/2.12.0 M2
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>