### PR TITLE
[eclipse/xtext#1916] Upgrade GSON to 2.8.6

### DIFF
--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -138,8 +138,8 @@
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
 		<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
 		<unit id="com.google.guava.source" version="27.1.0.v20190517-1946"/>
-		<unit id="com.google.gson" version="2.8.2.v20180104-1110"/>
-		<unit id="com.google.gson.source" version="2.8.2.v20180104-1110"/>
+		<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
+		<unit id="com.google.gson.source" version="2.8.6.v20201231-1626"/>
 		<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>
 		<unit id="org.antlr.runtime.source" version="3.2.0.v201101311130"/>
 		<unit id="org.junit" version="4.12.0.v201504281640"/>


### PR DESCRIPTION
Following platform upgrade of GSON from Bug#569966.

Signed-off-by: Karsten Thoms <karsten.thoms@karakun.com>