### PR TITLE
https://github.com/eclipse/xtext/issues/1862 Guava 30.1.0

### DIFF
--- a/releng/org.eclipse.xtend.sdk.feature/feature.xml
+++ b/releng/org.eclipse.xtend.sdk.feature/feature.xml
@@ -33,7 +33,7 @@ SPDX-License-Identifier: EPL-2.0
       <import plugin="org.eclipse.xtend.lib.macro" version="2.25.0" match="equivalent"/>
       <import plugin="org.eclipse.xtend.lib.source" version="2.25.0" match="equivalent"/>
       <import plugin="org.eclipse.xtend.lib.macro.source" version="2.25.0" match="equivalent"/>
-      <import plugin="com.google.guava" version="27.1.0" match="compatible"/>
+      <import plugin="com.google.guava" version="30.1.0" match="compatible"/>
       <import plugin="io.github.classgraph" version="4.8.35" match="compatible"/>
       <import plugin="org.apache.commons.lang"/>
    </requires>

--- a/releng/org.eclipse.xtext.redist.feature/feature.xml
+++ b/releng/org.eclipse.xtext.redist.feature/feature.xml
@@ -28,7 +28,7 @@ SPDX-License-Identifier: EPL-2.0
          version="0.0.0"/>
 
    <requires>
-      <import plugin="com.google.guava" version="27.1.0" match="compatible"/>
+      <import plugin="com.google.guava" version="30.1.0" match="compatible"/>
       <import plugin="com.google.inject" version="3.0.0" match="greaterOrEqual"/>
       <import plugin="org.objectweb.asm" version="9.0.0" match="compatible"/>
       <import plugin="javax.inject" version="1.0.0" match="greaterOrEqual"/>

--- a/releng/org.eclipse.xtext.runtime.feature/feature.xml
+++ b/releng/org.eclipse.xtext.runtime.feature/feature.xml
@@ -27,7 +27,7 @@ SPDX-License-Identifier: EPL-2.0
       <import plugin="org.eclipse.xtend"/>
       <import plugin="org.eclipse.xpand"/>
       <import plugin="org.eclipse.xtend.typesystem.emf"/>
-      <import plugin="com.google.guava" version="27.1.0" match="compatible"/>
+      <import plugin="com.google.guava" version="30.1.0" match="compatible"/>
       <import plugin="javax.inject" version="1.0.0" match="greaterOrEqual"/>
       <import plugin="com.google.inject" version="3.0.0" match="greaterOrEqual"/>
       <import plugin="org.objectweb.asm" version="9.0.0" match="compatible"/>

--- a/releng/org.eclipse.xtext.sdk.p2-repository/category.xml
+++ b/releng/org.eclipse.xtext.sdk.p2-repository/category.xml
@@ -6,8 +6,8 @@
    <feature id="org.eclipse.xtend.sdk" version="2.25.0.qualifier">
       <category name="Xtext"/>
    </feature>
-   <bundle id="com.google.guava" version="27.1.0.qualifier"/>
-   <bundle id="com.google.guava.source" version="27.1.0.qualifier"/>
+   <bundle id="com.google.guava" version="30.1.0.qualifier"/>
+   <bundle id="com.google.guava.source" version="30.1.0.qualifier"/>
    <bundle id="org.junit" version="4.12.0.qualifier"/>
    <bundle id="org.junit.source" version="4.12.0.qualifier"/>
    <bundle id="org.objectweb.asm" version="9.0.0.qualifier"/>

--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -136,8 +136,8 @@
 	</location>
 	
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<unit id="com.google.guava" version="27.1.0.v20190517-1946"/>
-		<unit id="com.google.guava.source" version="27.1.0.v20190517-1946"/>
+		<unit id="com.google.guava" version="30.1.0.v20210127-2300"/>
+		<unit id="com.google.guava.source" version="30.1.0.v20210127-2300"/>
 		<unit id="com.google.gson" version="2.8.6.v20201231-1626"/>
 		<unit id="com.google.gson.source" version="2.8.6.v20201231-1626"/>
 		<unit id="org.antlr.runtime" version="3.2.0.v201101311130"/>


### PR DESCRIPTION
Update Google Guava version from 27.1.0 to 30.1.0

Signed-off-by: miklossy <miklossy@itemis.de>