### PR TITLE
[eclipse/xtext#1928] Bootstrap against MWE(2) 1.6.1/2.12.1 Final

### DIFF
--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/feature.xml
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/feature.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <feature
       id="org.eclipse.emf.mwe2.language.sdk"
-      version="2.12.1.v20210201-1009"
+      version="2.12.1.v20210218-2134"
       label="Dummy Feature"
       provider-name="Eclipse Xtext">
 

--- a/releng/org.eclipse.emf.mwe2.language.sdk.dummy/pom.xml
+++ b/releng/org.eclipse.emf.mwe2.language.sdk.dummy/pom.xml
@@ -10,5 +10,5 @@
 	<packaging>eclipse-feature</packaging>
 	<groupId>org.eclipse.emf</groupId>
 	<artifactId>org.eclipse.emf.mwe2.language.sdk</artifactId>
-	<version>2.12.1.v20210201-1009</version>
+	<version>2.12.1.v20210218-2134</version>
 </project>

--- a/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
+++ b/releng/org.eclipse.xtext.sdk.target/org.eclipse.xtext.sdk.target.target
@@ -188,7 +188,7 @@
 	</location>
 
 	<location includeAllPlatforms="false" includeConfigurePhase="false" includeMode="planner" includeSource="true" type="InstallableUnit">
-		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/milestones/S202102011009/"/>
+		<repository location="https://download.eclipse.org/modeling/emft/mwe/updates/releases/2.12.1/"/>
 		<unit id="org.eclipse.emf.mwe2.lib" version="0.0.0"/>
 	</location>
 


### PR DESCRIPTION
[eclipse/xtext#1928] Bootstrap against MWE(2) 1.6.1/2.12.1 Final
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>