### PR TITLE
[eclipse/xtext#2110] dont run GenerateBuildshipPreferences.launch in background 

### DIFF
--- a/releng/gradle-composite/GenerateBuildshipPreferences.launch
+++ b/releng/gradle-composite/GenerateBuildshipPreferences.launch
@@ -1,15 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.buildship.core.launch.runconfiguration">
-<listAttribute key="arguments">
-<listEntry value="-PgeneratePrefs"/>
-</listAttribute>
-<stringAttribute key="gradle_distribution" value="GRADLE_DISTRIBUTION(WRAPPER)"/>
-<listAttribute key="jvm_arguments"/>
-<booleanAttribute key="show_console_view" value="true"/>
-<booleanAttribute key="show_execution_view" value="true"/>
-<listAttribute key="tasks">
-<listEntry value="generatePrefs"/>
-</listAttribute>
-<booleanAttribute key="use_gradle_distribution_from_import" value="false"/>
-<stringAttribute key="working_dir" value="${workspace_loc:/gradle-composite}"/>
+    <listAttribute key="arguments">
+        <listEntry value="-PgeneratePrefs"/>
+    </listAttribute>
+    <booleanAttribute key="build_scans_enabled" value="false"/>
+    <stringAttribute key="gradle_distribution" value="GRADLE_DISTRIBUTION(WRAPPER)"/>
+    <stringAttribute key="gradle_user_home" value=""/>
+    <stringAttribute key="java_home" value=""/>
+    <listAttribute key="jvm_arguments"/>
+    <booleanAttribute key="offline_mode" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.core.ATTR_FORCE_SYSTEM_CONSOLE_ENCODING" value="false"/>
+    <booleanAttribute key="org.eclipse.debug.ui.ATTR_LAUNCH_IN_BACKGROUND" value="false"/>
+    <booleanAttribute key="override_workspace_settings" value="false"/>
+    <booleanAttribute key="show_console_view" value="true"/>
+    <booleanAttribute key="show_execution_view" value="true"/>
+    <listAttribute key="tasks">
+        <listEntry value="generatePrefs"/>
+    </listAttribute>
+    <booleanAttribute key="use_gradle_distribution_from_import" value="false"/>
+    <stringAttribute key="working_dir" value="${workspace_loc:/gradle-composite}"/>
 </launchConfiguration>


### PR DESCRIPTION
[eclipse/xtext#2110] dont run GenerateBuildshipPreferences.launch in background 